### PR TITLE
refactor(parsan): extract RFC1035 label and subdomain rules into reusable types

### DIFF
--- a/parsan/rfc1035.go
+++ b/parsan/rfc1035.go
@@ -160,17 +160,10 @@ func (rule *RFC1035LabelRule) firstLetter() Rule {
 // lastLetter creates the rule that matches the final character of a label,
 // substituting an invalid character with the placeholder rune “x”.
 func (rule *RFC1035LabelRule) lastLetter() Rule {
-	switch {
-	case !rule.lowercase && !rule.mayStartWithDigit:
-		return LetDig(ReplaceFirstRuneWithStrings("x"))
-	case !rule.lowercase && rule.mayStartWithDigit:
-		return LetDig(ReplaceFirstRuneWithStrings("x"))
-	case rule.lowercase && !rule.mayStartWithDigit:
-		return LowerLetter(ReplaceFirstRuneWithStrings("x"))
-	case rule.lowercase && rule.mayStartWithDigit:
+	if rule.lowercase {
 		return LowerLetDig(ReplaceFirstRuneWithStrings("x"))
 	}
-	panic("cannot reach this point")
+	return LetDig(ReplaceFirstRuneWithStrings("x"))
 }
 
 // midLetter creates the optional rule that validates the middle characters of

--- a/parsan/rfc1035.go
+++ b/parsan/rfc1035.go
@@ -88,13 +88,7 @@ func suggestConstStringsIf(suggested []string, expected rune) SuggestionFunc {
 //   - Invalid last character: replaced with 'x'
 //   - Invalid middle characters: handled by the provided suggestFn
 func RFC1035Label(suggestFn SuggestionFunc) Rule {
-	return Concat(
-		Letter(PrependOrReplaceFirstRuneWithStrings("x")),
-		Opt(Concat(
-			Opt(LDHStr(suggestFn)),
-			LetDig(ReplaceFirstRuneWithStrings("x"))),
-		),
-	).WithMaxLength(63)
+	return GenerateRFC1035Label(suggestFn)
 }
 
 // RFC1035LabelRelaxed returns a Rule similar to RFC1035Label but allows labels
@@ -102,26 +96,14 @@ func RFC1035Label(suggestFn SuggestionFunc) Rule {
 // practice, as many systems accept labels beginning with digits despite the
 // strict RFC 1035 grammar.
 func RFC1035LabelRelaxed(suggestFn SuggestionFunc) Rule {
-	return Concat(
-		LetDig(PrependOrReplaceFirstRuneWithStrings("x")),
-		Opt(Concat(
-			Opt(LDHStr(suggestFn)),
-			LetDig(ReplaceFirstRuneWithStrings("x"))),
-		),
-	).WithMaxLength(63)
+	return GenerateRFC1035Label(suggestFn).MayStartWithDigit(true)
 }
 
 // RFC1035LowerLabel returns a Rule identical to RFC1035Label but restricts
 // letters to lowercase only (a-z). This is useful when case-normalized labels
 // are required, enabling case-insensitive comparisons via exact string matching.
 func RFC1035LowerLabel(suggestFn SuggestionFunc) Rule {
-	return Concat(
-		LowerLetter(PrependOrReplaceFirstRuneWithStrings("x")),
-		Opt(Concat(
-			Opt(LowerLDHStr(suggestFn)),
-			LowerLetDig(ReplaceFirstRuneWithStrings("x"))),
-		),
-	).WithMaxLength(63)
+	return GenerateRFC1035Label(suggestFn).LowercaseOnly(true)
 }
 
 // RFC1035LowerLabelRelaxed returns a Rule that combines the relaxed starting
@@ -129,13 +111,117 @@ func RFC1035LowerLabel(suggestFn SuggestionFunc) Rule {
 // Labels may start with a lowercase letter or digit and contain only lowercase
 // letters, digits, and hyphens.
 func RFC1035LowerLabelRelaxed(suggestFn SuggestionFunc) Rule {
-	return Concat(
-		LowerLetDig(PrependOrReplaceFirstRuneWithStrings("x")),
+	return GenerateRFC1035Label(suggestFn).
+		MayStartWithDigit(true).
+		LowercaseOnly(true)
+}
+
+// RFC1035LabelRule is the concrete implementation of a DNS label rule.
+// It embeds a generic Rule and adds configuration fields used to build the
+// underlying parsing expression.
+type RFC1035LabelRule struct {
+	Rule
+	suggestFn         SuggestionFunc
+	lowercase         bool
+	mayStartWithDigit bool
+	maxLen            int
+}
+
+// generate constructs the parsing expression for the label based on the
+// current configuration (lowercase enforcement, digit‑start allowance, and
+// maximum length) and stores it in the embedded Rule field.
+func (rule *RFC1035LabelRule) generate() {
+	rule.Rule = Concat(
+		rule.firstLetter(),
 		Opt(Concat(
-			Opt(LowerLDHStr(suggestFn)),
-			LowerLetDig(ReplaceFirstRuneWithStrings("x"))),
-		),
-	).WithMaxLength(63)
+			rule.midLetter(),
+			rule.lastLetter(),
+		)),
+	).WithMaxLength(rule.maxLen)
+}
+
+// firstLetter creates the rule that matches the first character of a label,
+// taking into account whether digits are allowed to start the label and whether
+// only lowercase letters are permitted.
+func (rule *RFC1035LabelRule) firstLetter() Rule {
+	switch {
+	case !rule.lowercase && !rule.mayStartWithDigit:
+		return Letter(PrependOrReplaceFirstRuneWithStrings("x"))
+	case !rule.lowercase && rule.mayStartWithDigit:
+		return LetDig(PrependOrReplaceFirstRuneWithStrings("x"))
+	case rule.lowercase && !rule.mayStartWithDigit:
+		return LowerLetter(PrependOrReplaceFirstRuneWithStrings("x"))
+	case rule.lowercase && rule.mayStartWithDigit:
+		return LowerLetDig(PrependOrReplaceFirstRuneWithStrings("x"))
+	}
+	panic("cannot reach this point")
+}
+
+// lastLetter creates the rule that matches the final character of a label,
+// substituting an invalid character with the placeholder rune “x”.
+func (rule *RFC1035LabelRule) lastLetter() Rule {
+	switch {
+	case !rule.lowercase && !rule.mayStartWithDigit:
+		return LetDig(ReplaceFirstRuneWithStrings("x"))
+	case !rule.lowercase && rule.mayStartWithDigit:
+		return LetDig(ReplaceFirstRuneWithStrings("x"))
+	case rule.lowercase && !rule.mayStartWithDigit:
+		return LowerLetter(ReplaceFirstRuneWithStrings("x"))
+	case rule.lowercase && rule.mayStartWithDigit:
+		return LowerLetDig(ReplaceFirstRuneWithStrings("x"))
+	}
+	panic("cannot reach this point")
+}
+
+// midLetter creates the optional rule that validates the middle characters of
+// a label (the “ldh‑str” part) and applies the provided suggestion function for
+// any invalid characters.
+func (rule *RFC1035LabelRule) midLetter() Rule {
+	if !rule.lowercase {
+		return Opt(LDHStr(rule.suggestFn))
+	} else {
+		return Opt(LowerLDHStr(rule.suggestFn))
+	}
+}
+
+// LowercaseOnly configures the rule to accept only lowercase letters.
+// It regenerates the underlying expression to reflect the new setting.
+func (rule *RFC1035LabelRule) LowercaseOnly(b bool) *RFC1035LabelRule {
+	rule.lowercase = b
+	rule.generate()
+	return rule
+}
+
+// MayStartWithDigit configures the rule to allow a digit as the first
+// character of a label. It regenerates the underlying expression to
+// reflect the new setting.
+func (rule *RFC1035LabelRule) MayStartWithDigit(b bool) *RFC1035LabelRule {
+	rule.mayStartWithDigit = b
+	rule.generate()
+	return rule
+}
+
+// MaxLength sets the maximum allowed length for the label and rebuilds the
+// parsing expression accordingly.
+func (rule *RFC1035LabelRule) MaxLength(l int) *RFC1035LabelRule {
+	rule.maxLen = l
+	rule.generate()
+	return rule
+}
+
+// GenerateRFC1035Label creates a new RFC1035LabelRule with the
+// supplied SuggestionFunc. The rule starts with the strict RFC‑1035
+// defaults (lowercase disabled, digit‑start disabled, max length 63)
+// and then builds its internal expression.
+func GenerateRFC1035Label(suggestFn SuggestionFunc) *RFC1035LabelRule {
+	rule := &RFC1035LabelRule{
+		suggestFn:         suggestFn,
+		lowercase:         false,
+		mayStartWithDigit: false,
+		maxLen:            63,
+	}
+	rule.generate()
+	return rule
 }
 
 // subdomainSuggestFn is a SuggestionFunc that handles invalid characters within
@@ -165,55 +251,84 @@ var subdomainSuggestFn = MergeSuggestionFuncs(
 // Invalid characters within labels are sanitized as follows:
 //   - '@' is replaced with "-at-" or "-" (both options explored)
 //   - Other invalid characters are replaced with '-'
-var RFC1035Subdomain = Named("rfc1035-subdomain",
-	Alternative(
-		RFC1035Label(subdomainSuggestFn),
-		Concat(
-			RFC1035Label(subdomainSuggestFn),
-			Terminal("."),
-			Ref("rfc1035-subdomain"),
-		),
-	)).WithMaxLength(253)
+var RFC1035Subdomain = GenerateRFC1035Subdomain()
 
 // RFC1035SubdomainRelaxed is a Rule similar to RFC1035Subdomain but uses
 // RFC1035LabelRelaxed for each label, allowing labels to start with digits.
 // This accommodates the common practice of using digit-prefixed labels in
 // DNS names.
-var RFC1035SubdomainRelaxed = Named("rfc1035-subdomain-relaxed",
-	Alternative(
-		RFC1035LabelRelaxed(subdomainSuggestFn),
-		Concat(
-			RFC1035LabelRelaxed(subdomainSuggestFn),
-			Terminal("."),
-			Ref("rfc1035-subdomain-relaxed"),
-		),
-	)).WithMaxLength(253)
+var RFC1035SubdomainRelaxed = GenerateRFC1035Subdomain().LabelMayStartWithDigit(true)
 
 // RFC1035LowerSubdomain is a Rule identical to RFC1035Subdomain but enforces
 // lowercase letters throughout all labels. This produces case-normalized
 // subdomain strings suitable for systems that perform case-insensitive DNS
 // comparisons via exact string matching.
-var RFC1035LowerSubdomain = Named("rfc1035-lower-subdomain",
-	Alternative(
-		RFC1035LowerLabel(subdomainSuggestFn),
-		Concat(
-			RFC1035LowerLabel(subdomainSuggestFn),
-			Terminal("."),
-			Ref("rfc1035-lower-subdomain"),
-		),
-	)).WithMaxLength(253)
+var RFC1035LowerSubdomain = GenerateRFC1035Subdomain().LowercaseOnlyLabel(true)
 
 // RFC1035LowerSubdomainRelaxed is a Rule that combines relaxed starting
 // character requirements with lowercase letter enforcement. Labels may
 // start with a lowercase letter or digit, and all letters are restricted
 // to lowercase. This is the most permissive variant while still enforcing
 // case normalization.
-var RFC1035LowerSubdomainRelaxed = Named("rfc1035-lower-subdomain-relaxed",
-	Alternative(
-		RFC1035LowerLabelRelaxed(subdomainSuggestFn),
-		Concat(
-			RFC1035LowerLabelRelaxed(subdomainSuggestFn),
-			Terminal("."),
-			Ref("rfc1035-lower-subdomain-relaxed"),
-		),
-	)).WithMaxLength(253)
+var RFC1035LowerSubdomainRelaxed = GenerateRFC1035Subdomain().
+	LowercaseOnlyLabel(true).
+	LabelMayStartWithDigit(true)
+
+// RFC1035SubdomainRule defines a parser rule for a full DNS subdomain.
+// It contains a reference to the label rule used for each component.
+type RFC1035SubdomainRule struct {
+	Rule
+	Label *RFC1035LabelRule
+}
+
+// generate builds the recursive parsing expression for a subdomain.
+// It uses a unique rule name to allow the rule to refer to itself.
+func (r *RFC1035SubdomainRule) generate() {
+	name := GenerateUniqueName()
+	r.Rule = Named(name,
+		Alternative(
+			r.Label,
+			Concat(
+				r.Label,
+				Terminal("."),
+				Ref(name),
+			),
+		)).WithMaxLength(253)
+}
+
+// LowercaseOnlyLabel configures the inner label rule to enforce
+// lowercase letters only, then rebuilds the subdomain expression.
+func (r *RFC1035SubdomainRule) LowercaseOnlyLabel(b bool) *RFC1035SubdomainRule {
+	r.Label = r.Label.LowercaseOnly(b)
+	r.generate()
+	return r
+}
+
+// LabelMayStartWithDigit configures the inner label rule to allow a
+// digit as the first character of each label, then rebuilds the
+// subdomain expression.
+func (r *RFC1035SubdomainRule) LabelMayStartWithDigit(b bool) *RFC1035SubdomainRule {
+	r.Label = r.Label.MayStartWithDigit(b)
+	r.generate()
+	return r
+}
+
+// LabelMaxLength sets a maximum length for each label within the
+// subdomain and rebuilds the parsing expression.
+func (r *RFC1035SubdomainRule) LabelMaxLength(l int) *RFC1035SubdomainRule {
+	r.Label = r.Label.MaxLength(l)
+	r.generate()
+	return r
+}
+
+// GenerateRFC1035Subdomain creates a new subdomain rule using the
+// default subdomain suggestion function. The returned rule can be
+// further tuned (e.g., relaxed digit start, lowercase enforcement)
+// via its methods.
+func GenerateRFC1035Subdomain() *RFC1035SubdomainRule {
+	r := &RFC1035SubdomainRule{
+		Label: GenerateRFC1035Label(subdomainSuggestFn),
+	}
+	r.generate()
+	return r
+}

--- a/parsan/rfc1035_test.go
+++ b/parsan/rfc1035_test.go
@@ -102,4 +102,71 @@ var _ = Describe("Rfc1035", func() {
 			}))
 		})
 	})
+	Describe("RFC1035Subdomain with long subdomains", func() {
+		var rule parsan.Rule
+
+		BeforeEach(func() {
+			rule = parsan.GenerateRFC1035Subdomain().LabelMaxLength(253)
+		})
+		It("sanitizes ''", func() {
+			Expect(parsan.ParseAndSanitize("", rule)).To(Equal([]string{"x"}))
+		})
+		It("matches 'kubernetes-custom-resource'", func() {
+			Expect(parsan.ParseAndSanitize("kubernetes-custom-resource", rule)).To(Equal([]string{"kubernetes-custom-resource"}))
+		})
+		It("sanitizes '1kubernetes-custom-resource'", func() {
+			Expect(parsan.ParseAndSanitize("1kubernetes-custom-resource", rule)).To(Equal([]string{"x1kubernetes-custom-resource", "xkubernetes-custom-resource"}))
+		})
+		It("matches 'kubernetes-custom-resource1'", func() {
+			Expect(parsan.ParseAndSanitize("kubernetes-custom-resource1", rule)).To(Equal([]string{"kubernetes-custom-resource1"}))
+		})
+		It("matches 'a.b'", func() {
+			Expect(parsan.ParseAndSanitize("a.b", rule)).To(Equal([]string{"a.b"}))
+		})
+		It("matches 'a.b.c'", func() {
+			Expect(parsan.ParseAndSanitize("a.b.c", rule)).To(Equal([]string{"a.b.c"}))
+		})
+		It("matches 'kubernetes.custom.resource'", func() {
+			Expect(parsan.ParseAndSanitize("kubernetes.custom.resource", rule)).To(Equal([]string{"kubernetes.custom.resource"}))
+		})
+		It("matches 'kubernetes1.custom2.resource3'", func() {
+			Expect(parsan.ParseAndSanitize("kubernetes1.custom2.resource3", rule)).To(Equal([]string{"kubernetes1.custom2.resource3"}))
+		})
+		It("sanitizes '1kubernetes.2custom.1resource'", func() {
+			Expect(parsan.ParseAndSanitize("1kubernetes.2custom.3resource", rule)).To(Equal([]string{
+				"x1kubernetes.x2custom.x3resource",
+				"x1kubernetes.x2custom.xresource",
+				"x1kubernetes.xcustom.x3resource",
+				"xkubernetes.x2custom.x3resource",
+				"x1kubernetes.xcustom.xresource",
+				"xkubernetes.x2custom.xresource",
+				"xkubernetes.xcustom.x3resource",
+				"xkubernetes.xcustom.xresource",
+			}))
+		})
+		It("sanitizes 'do+it+now'", func() {
+			Expect(parsan.ParseAndSanitize("do+it+now", rule)).To(Equal([]string{"do-it-now"}))
+		})
+		It("sanitizes 'do+it+now.r!ght.n0w$'", func() {
+			Expect(parsan.ParseAndSanitize("do+it+now.r!ght.n0w$", rule)).To(Equal([]string{"do-it-now.r-ght.n0wx"}))
+		})
+		It("matches 'a23456789012345678901234567890123456789012345678901234567890123'", func() {
+			Expect(parsan.ParseAndSanitize("a23456789012345678901234567890123456789012345678901234567890123", rule)).To(Equal([]string{"a23456789012345678901234567890123456789012345678901234567890123"}))
+		})
+		It("sanitizes 'a234567890123456789012345678901234567890123456789012345678901234'", func() {
+			Expect(parsan.ParseAndSanitize("a234567890123456789012345678901234567890123456789012345678901234", rule)).To(Equal([]string{"a234567890123456789012345678901234567890123456789012345678901234"}))
+		})
+		It("sanitizes '123456789012345678901234567890123456789012345678901234567890123'", func() {
+			Expect(parsan.ParseAndSanitize("123456789012345678901234567890123456789012345678901234567890123", rule)).To(Equal([]string{
+				"x123456789012345678901234567890123456789012345678901234567890123",
+				"x23456789012345678901234567890123456789012345678901234567890123",
+			}))
+		})
+		It("sanitizes '1234567890123456789012345678901234567890123456789012345678901234'", func() {
+			Expect(parsan.ParseAndSanitize("1234567890123456789012345678901234567890123456789012345678901234", rule)).To(Equal([]string{
+				"x1234567890123456789012345678901234567890123456789012345678901234",
+				"x234567890123456789012345678901234567890123456789012345678901234",
+			}))
+		})
+	})
 })


### PR DESCRIPTION
Refactors the RFC1035 label and subdomain parsing rules to use dedicated types with builder methods instead of inline `Concat`/`Alternative` expressions.

### Changes

- **New types**: `RFC1035LabelRule` and `RFC1035SubdomainRule` with builder methods:
  - `LowercaseOnly(b bool)` / `LowercaseOnlyLabel(b bool)`
  - `MayStartWithDigit(b bool)` / `LabelMayStartWithDigit(b bool)`
  - `MaxLength(l int)` / `LabelMaxLength(l int)`
- **New factory functions**: `GenerateRFC1035Label()` and `GenerateRFC1035Subdomain()`
- **Simplified existing functions**: `RFC1035Label*` and `RFC1035Subdomain*` variants now delegate to the new types
- **New tests**: Added test coverage for long subdomain parsing with various sanitization scenarios

### Motivation

The previous implementation duplicated parsing logic across multiple functions. Extracting a reusable type with builder methods improves maintainability and allows for easier configuration of label/subdomain rules.

### Testing

- All existing tests pass
- Added 14 new test cases for subdomain sanitization with long labels

### Breaking Changes

None - all existing APIs remain functional.
