### PR TITLE
docs: rename markdown files to mdx and add sidebar positions

### DIFF
--- a/docs/contribution-notes/contributing.mdx
+++ b/docs/contribution-notes/contributing.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 0
+---
+
 # Contributing to xp-clifford
 
 ## General Remarks

--- a/docs/end-user-guides/configuration.mdx
+++ b/docs/end-user-guides/configuration.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Configuration Parameters
 
 `xp-clifford` provides typed configuration parameters that support three input methods with a defined precedence:

--- a/docs/end-user-guides/error-handling.mdx
+++ b/docs/end-user-guides/error-handling.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # Error Handling with Attributes
 
 The `erratt` package provides an error type with structured key-value attributes, designed for use with `slog` and the `EventHandler.Warn` method.

--- a/docs/end-user-guides/exporting-resources.mdx
+++ b/docs/end-user-guides/exporting-resources.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Exporting Resources
 
 The `export` subcommand is mandatory but requires you to implement the export logic.

--- a/docs/end-user-guides/getting-started.mdx
+++ b/docs/end-user-guides/getting-started.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 0
+---
+
 # Getting Started
 
 ## Prerequisites

--- a/docs/end-user-guides/mkcontainer.mdx
+++ b/docs/end-user-guides/mkcontainer.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 7
+---
+
 # mkcontainer — Multi-Key Container
 
 The `mkcontainer` package provides a thread-safe container for storing and retrieving items indexed by multiple keys.

--- a/docs/end-user-guides/overview.mdx
+++ b/docs/end-user-guides/overview.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Overview
 
 `xp-clifford` (Crossplane CLI Framework for Resource Data Extraction) is a Go module for building CLI tools that export definitions of external resources as Crossplane provider managed resource definitions.

--- a/docs/end-user-guides/sanitization.mdx
+++ b/docs/end-user-guides/sanitization.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 8
+---
+
 # Parsing and Sanitization
 
 The `parsan` package transforms strings to conform with Kubernetes object naming rules.

--- a/docs/end-user-guides/subcommands.mdx
+++ b/docs/end-user-guides/subcommands.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Custom Subcommands
 
 Beyond the built-in `export` subcommand, you can define custom subcommands by implementing the `cli.SubCommand` interface or using `cli.BasicSubCommand`.

--- a/docs/end-user-guides/widgets.mdx
+++ b/docs/end-user-guides/widgets.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Interactive Widgets
 
 `xp-clifford` provides terminal UI widgets for user interaction. Widgets require an interactive terminal — when running in an IDE, enable terminal emulation (e.g., GoLand: *Emulate terminal in output console*).


### PR DESCRIPTION
Rename all documentation files from .md to .mdx to enable MDX support for Docusaurus. Add frontmatter with sidebar_position to each file to control documentation sidebar ordering.