### PR TITLE
docs: rename documentation file references from .md to .mdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 
 ## Documentation
 
-- [Overview](docs/end-user-guides/overview.md)
-- [Getting Started](docs/end-user-guides/getting-started.md)
-- [Exporting Resources](docs/end-user-guides/exporting-resources.md)
-- [Configuration Parameters](docs/end-user-guides/configuration.md)
-- [Interactive Widgets](docs/end-user-guides/widgets.md)
-- [Custom Subcommands](docs/end-user-guides/subcommands.md)
-- [Error Handling](docs/end-user-guides/error-handling.md)
-- [Parsing and Sanitization](docs/end-user-guides/sanitization.md)
-- [mkcontainer Package](docs/end-user-guides/mkcontainer.md)
+- [Overview](docs/end-user-guides/overview.mdx)
+- [Getting Started](docs/end-user-guides/getting-started.mdx)
+- [Exporting Resources](docs/end-user-guides/exporting-resources.mdx)
+- [Configuration Parameters](docs/end-user-guides/configuration.mdx)
+- [Interactive Widgets](docs/end-user-guides/widgets.mdx)
+- [Custom Subcommands](docs/end-user-guides/subcommands.mdx)
+- [Error Handling](docs/end-user-guides/error-handling.mdx)
+- [Parsing and Sanitization](docs/end-user-guides/sanitization.mdx)
+- [mkcontainer Package](docs/end-user-guides/mkcontainer.mdx)
 
 ## Support, Feedback, Contributing
 

--- a/docs/end-user-guides/getting-started.mdx
+++ b/docs/end-user-guides/getting-started.mdx
@@ -68,7 +68,7 @@ Flags:
 
 ## Next Steps
 
-- [Exporting Resources](./exporting-resources.md) — Implement the export logic
-- [Configuration](./configuration.md) — Add CLI flags, env vars, and config files
-- [Widgets](./widgets.md) — Add interactive prompts
-- [Subcommands](./subcommands.md) — Add custom subcommands
+- [Exporting Resources](./exporting-resources.mdx) — Implement the export logic
+- [Configuration](./configuration.mdx) — Add CLI flags, env vars, and config files
+- [Widgets](./widgets.mdx) — Add interactive prompts
+- [Subcommands](./subcommands.mdx) — Add custom subcommands

--- a/docs/end-user-guides/widgets.mdx
+++ b/docs/end-user-guides/widgets.mdx
@@ -49,4 +49,4 @@ Widgets integrate with configuration parameters via `ValueOrAsk(ctx)`:
 - `StringParam.ValueOrAsk(ctx)` — uses `TextInput`
 - `StringSliceParam.ValueOrAsk(ctx)` — uses `MultiInput` (requires `WithPossibleValues` or `WithPossibleValuesFn`)
 
-See [Configuration](./configuration.md) for details.
+See [Configuration](./configuration.mdx) for details.


### PR DESCRIPTION
Update all internal links and references in README.md and end-user guides to point to the correct .mdx file extensions, reflecting the actual filenames in the repository.