### PR TITLE
feat: add timeout config parameter

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/SAP/xp-clifford/cli/configparam"
 	"github.com/SAP/xp-clifford/erratt"
@@ -16,6 +17,9 @@ func init() {
 }
 
 var rootCommand *cobra.Command
+
+var TimeoutParam = configparam.Duration("timeout", "API request timeout").
+	WithDefaultValue(30 * time.Second)
 
 // Execute function is the main entrypoint for the CLI tool.
 func Execute() {
@@ -44,6 +48,10 @@ type CLIConfiguration struct {
 	// HasVerboseFlag indicates whether the CLI tool shall support
 	// the --verbose/-v flag.
 	HasVerboseFlag bool
+
+	// HasTimeoutParam indicates whether the CLI tool shall support
+	// the --timeout duration parameter.
+	HasTimeoutParam bool
 }
 
 func defaultCLIConfiguration() CLIConfiguration {
@@ -52,6 +60,7 @@ func defaultCLIConfiguration() CLIConfiguration {
 		ShortName:       "SHORTNAME_NOT_SET",
 		ObservedSystem:  "OBSERVED_SYSTEM_NOT_SET",
 		HasVerboseFlag:  true,
+		HasTimeoutParam: true,
 	}
 }
 
@@ -98,10 +107,16 @@ func configureCLI() error {
 			if config.HasVerboseFlag {
 				verboseFlag.BindConfiguration(cmd)
 			}
+			if config.HasTimeoutParam {
+				TimeoutParam.BindConfiguration(cmd)
+			}
 		},
 	}
 	if config.HasVerboseFlag {
 		verboseFlag.AttachToCommand(rootCommand)
+	}
+	if config.HasTimeoutParam {
+		TimeoutParam.AttachToCommand(rootCommand)
 	}
 
 	return nil

--- a/cli/cli_internal_test.go
+++ b/cli/cli_internal_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import "testing"
+
+func TestDefaultCLIConfigurationHasTimeoutParam(t *testing.T) {
+	config := defaultCLIConfiguration()
+	if !config.HasTimeoutParam {
+		t.Fatal("expected timeout parameter to be enabled by default")
+	}
+}
+
+func TestConfigureCLIAttachesTimeoutParam(t *testing.T) {
+	originalConfig := Configuration.CLIConfiguration
+	originalRootCommand := rootCommand
+	defer func() {
+		Configuration.CLIConfiguration = originalConfig
+		rootCommand = originalRootCommand
+	}()
+
+	Configuration.CLIConfiguration = defaultCLIConfiguration()
+
+	if err := configureCLI(); err != nil {
+		t.Fatal(err)
+	}
+
+	flag := rootCommand.PersistentFlags().Lookup("timeout")
+	if flag == nil {
+		t.Fatal("expected timeout flag to be registered")
+	}
+	if flag.DefValue != "30s" {
+		t.Fatalf("expected default timeout 30s, got %q", flag.DefValue)
+	}
+}
+
+func TestConfigureCLICanDisableTimeoutParam(t *testing.T) {
+	originalConfig := Configuration.CLIConfiguration
+	originalRootCommand := rootCommand
+	defer func() {
+		Configuration.CLIConfiguration = originalConfig
+		rootCommand = originalRootCommand
+	}()
+
+	config := defaultCLIConfiguration()
+	config.HasTimeoutParam = false
+	Configuration.CLIConfiguration = config
+
+	if err := configureCLI(); err != nil {
+		t.Fatal(err)
+	}
+
+	if flag := rootCommand.PersistentFlags().Lookup("timeout"); flag != nil {
+		t.Fatal("expected timeout flag to be disabled")
+	}
+}

--- a/docs/end-user-guides/configuration.mdx
+++ b/docs/end-user-guides/configuration.mdx
@@ -113,7 +113,11 @@ Global flags:
 | Flag              | Type     | Description                |
 |-------------------|----------|----------------------------|
 | `-c`, `--config`  | `string` | Path to configuration file |
+| `--timeout`       | `duration` | API request timeout        |
 | `-v`, `--verbose` | `bool`   | Enable debug-level logging |
+
+The built-in timeout is available as `cli.TimeoutParam.Value()` and defaults to `30s`.
+Set `cli.Configuration.HasTimeoutParam = false` to disable it.
 
 ## Configuration File
 

--- a/docs/end-user-guides/getting-started.mdx
+++ b/docs/end-user-guides/getting-started.mdx
@@ -63,6 +63,7 @@ Available Commands:
 Flags:
   -c, --config string   Configuration file
   -h, --help            help for test-exporter
+      --timeout duration   API request timeout (default 30s)
   -v, --verbose         Verbose output
 ```
 


### PR DESCRIPTION
Fixes #9.\n\nAdds a built-in duration timeout parameter with a 30s default, plus a configuration switch to disable it.\n\nChecks:\n- go test ./...\n- git diff --check