### PR TITLE
fix: absolute paths for contribution-notes links in exporter-install

### DIFF
--- a/docs/end-user-guides/exporter-install.mdx
+++ b/docs/end-user-guides/exporter-install.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 An exporter CLI is available for both **BTP** and **Cloud Foundry**. Select the tab for your provider below.
 
 Want to bring this feature to any Crossplane provider?
-Checkout [xp-clifford](./contribution-notes/overview) and see our [contribution docs](./contribution-notes/getting-started) to learn how.
+Checkout [xp-clifford](/docs/xp-clifford/docs/contribution-notes/overview) and see our [contribution docs](/docs/xp-clifford/docs/contribution-notes/getting-started) to learn how.
 
 <Tabs>
   <TabItem value="btp" label="BTP" default>


### PR DESCRIPTION
## Summary

After moving `exporter-install.mdx` into `end-user-guides/`, relative links to `./contribution-notes/...` resolved to `end-user-guides/contribution-notes/...` which doesn't exist. Switches them to absolute paths.

Fixes broken links reported in https://github.com/SAP/crossplane-provider-docs/actions/runs/32014862040.